### PR TITLE
Added dependency package -> exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,10 +24,10 @@ BACKSPACE="<%= @backspace %>"
 ')
   }
 
-  exec { 'apply':
+  exec { 'apply-keyboard-configuration':
     command     => '/usr/sbin/dpkg-reconfigure -f noninteractive keyboard-configuration',
     subscribe   => File['/etc/default/keyboard'],
-    require     => File['/etc/default/keyboard'],
+    require     => [ File['/etc/default/keyboard'], Package['keyboard-configuration'], ],
     refreshonly => true
   }
 }


### PR DESCRIPTION
We need to ensure that the keyboard-configuration package is installed before we try to reconfigured it. I also changed the name of the exec resource from apply to apply-keyboard-configuration to reduce the risk of collision.
